### PR TITLE
oreilly_review_table: Fix crashed with Sphinx-2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 
 long_desc = open('README.rst').read()
 
-requires = ['Sphinx>=1.6', 'sphinxcontrib-reviewbuilder>=0.0.8']
+requires = ['Sphinx>=2.0', 'sphinxcontrib-reviewbuilder>=0.0.8']
 
 setup(
     name='sphinxcontrib-getstart-sphinx',

--- a/sphinxcontrib/getstart_sphinx/oreilly_review_table.py
+++ b/sphinxcontrib/getstart_sphinx/oreilly_review_table.py
@@ -8,14 +8,17 @@ oreilly_review_table
 """
 
 from docutils import nodes
-from sphinx.writers.text import TextTranslator
+from sphinx.writers.text import Cell, TextTranslator
 
 
 def visit_entry(self, node):
     if len(node) == 0:
-        # Fill single-dot ``.`` for empty table cells
-        self.table[-1].append(u'　')
-        raise nodes.SkipNode
+        # Fill full-width space for empty table cells
+        self.entry = Cell()
+        self.new_state(0)
+        self.new_state(0)
+        self.add_text('　')
+        self.end_state()
     else:
         TextTranslator.visit_entry(self, node)
 


### PR DESCRIPTION
The internal structure for tables of TextBuilder has been changed since
Sphinx-2.0.  So oreilly_review_table is crashed with it.

This follows the new structure to support it.